### PR TITLE
change if logic in linux/storage/init.sls

### DIFF
--- a/linux/storage/init.sls
+++ b/linux/storage/init.sls
@@ -1,5 +1,5 @@
 {%- from "linux/map.jinja" import storage with context %}
-{%- if storage.mount|length > 0 or storage.swap|length > 0 or storage.multipath.enabled %}
+{%- if storage.enabled %}
 include:
 {%- if storage.mount|length > 0 %}
 - linux.storage.mount
@@ -13,4 +13,5 @@ include:
 {%- if storage.multipath.enabled %}
 - linux.storage.multipath
 {%- endif %}
+
 {%- endif %}


### PR DESCRIPTION
Unable to install lvm action. I thought first just adding `storage.lvm|length>0` but it seems redundant.
Change the if statement to check for `storage.enabled` instead.
One downfall to this patch is that if you have storage.enabled == True
but not enable any of the storage methods, then salt produces the following error

```
'local': ['Include Declaration in SLS linux.storage is not formed as a list', 'ID include in SLS linux.storage is not a dictionary']}
```
