### PR TITLE
The afd module requires "hostname" to be set

### DIFF
--- a/linux/meta/heka.yml
+++ b/linux/meta/heka.yml
@@ -52,6 +52,7 @@ metric_collector:
         afd_logical_name: 'cpu'
         activate_alerting: true
         enable_notification: false
+        hostname: '{{ grains.fqdn.split('.')[0] }}'
     linux_swap_utilization:
       engine: sandbox
       module_file: /usr/share/lma_collector/filters/afd.lua
@@ -66,3 +67,4 @@ metric_collector:
         afd_logical_name: 'swap'
         activate_alerting: true
         enable_notification: false
+        hostname: '{{ grains.fqdn.split('.')[0] }}'


### PR DESCRIPTION
Eventually alarms will be defined in a completely different way, but this just provides a temporary fix for the current implementation.