### PR TITLE
Remove the alarm-related filters

### DIFF
--- a/linux/meta/heka.yml
+++ b/linux/meta/heka.yml
@@ -37,32 +37,4 @@ log_collector:
         interval: 60
         grace_interval: 30
 metric_collector:
-  filter:
-    linux_cpu_utilization:
-      engine: sandbox
-      module_file: /usr/share/lma_collector/filters/afd.lua
-      module_dir: /usr/share/lma_collector_modules;/usr/share/heka/lua_modules
-      preserve_data: false
-      message_matcher: "(Type == 'metric' || Type == 'heka.sandbox.metric') && (Fields[name] == 'cpu_idle' || Fields[name] == 'cpu_wait')"
-      ticker_interval: 10
-      config:
-        afd_type: 'node'
-        afd_file: 'lma_alarms_controller_cpu'
-        afd_cluster_name: 'controller'
-        afd_logical_name: 'cpu'
-        activate_alerting: true
-        enable_notification: false
-    linux_swap_utilization:
-      engine: sandbox
-      module_file: /usr/share/lma_collector/filters/afd.lua
-      module_dir: /usr/share/lma_collector_modules;/usr/share/heka/lua_modules
-      preserve_data: false
-      message_matcher: "(Type == 'metric' || Type == 'heka.sandbox.metric') && (Fields[name] == 'swap_free' || Fields[name] == 'swap_io_in' || Fields[name] == 'swap_io_out' || Fields[name] == 'swap_percent_used')"
-      ticker_interval: 10
-      config:
-        afd_type: 'node'
-        afd_file: 'lma_alarms_controller_swap'
-        afd_cluster_name: 'controller'
-        afd_logical_name: 'swap'
-        activate_alerting: true
-        enable_notification: false
+  filter: {}


### PR DESCRIPTION
This commit removes the alarm-related filter configuration from `meta/heka.yml`. Alarms will be defined in a different way (still under discussion).