### PR TITLE
Fix decoder name

### DIFF
--- a/linux/meta/heka.yml
+++ b/linux/meta/heka.yml
@@ -1,6 +1,6 @@
 log_collector:
   decoder:
-    linux_syslog:
+    system:
       engine: sandbox
       module_file: /usr/share/lma_collector/decoders/generic_syslog.lua
       module_dir: /usr/share/lma_collector_modules;/usr/share/heka/lua_modules


### PR DESCRIPTION
This fixes the decoder name in `meta/heka.yml`.