### PR TITLE
Add timezone to syslog decoder config

### DIFF
--- a/linux/meta/heka.yml
+++ b/linux/meta/heka.yml
@@ -1,3 +1,4 @@
+{%- from "linux/map.jinja" import system with context %}
 log_collector:
   decoder:
     system:
@@ -7,6 +8,9 @@ log_collector:
       config:
         syslog_pattern: '<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%\n'
         fallback_syslog_pattern: '%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%\n'
+{%- if system.timezone is defined %}
+        tz: "{{ system.timezone }}"
+{%- endif %}
   input:
     linux_log_stream:
       engine: logstreamer


### PR DESCRIPTION
If `system.timezone` is defined this sets `tz` in the syslog/system decoder configuration. This is required to get correct dates in log messages sent to Elasticsearch.