### PR TITLE
xmit_hash_policy to hashing-alghoritm

### DIFF
--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -71,7 +71,7 @@
     'ad_select',
     'downdelay',
     'updelay',
-    'xmit_hash_policy',
+    'hashing-algorithm',
 ] %}
 
 {% set network = salt['grains.filter_by']({


### PR DESCRIPTION
There is an error in salt doc. Hashing-alghoritm is correct, https://github.com/saltstack/salt/blob/90bbf8dc4f3c9eba09107821309ff7b07df93c3b/salt/modules/debian_ip.py#L1045