### PR TITLE
Use netlink collectd plugin instead of interface

### DIFF
--- a/_modules/netlink.py
+++ b/_modules/netlink.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+_alphanum_re = re.compile(r'^[a-z0-9]+$')
+_lo_re = re.compile(r'^lo$')
+
+
+def _filter(interface):
+    return _alphanum_re.match(interface) and not _lo_re.match(interface)
+
+
+def ls():
+    """
+    Provide a list of network interfaces.
+    """
+    return filter(_filter, __salt__['grains.get']('ip_interfaces', {}).keys())

--- a/linux/files/collectd_netlink.conf
+++ b/linux/files/collectd_netlink.conf
@@ -1,0 +1,10 @@
+<LoadPlugin netlink>
+  Globals false
+</LoadPlugin>
+
+<Plugin netlink>
+  {%- for interface_name in plugin.get('interfaces', []) %}
+  VerboseInterface "{{ interface_name }}"
+  {%- endfor %}
+  IgnoreSelected {{ plugin.get('ignore_selected', False)|lower }}
+</Plugin>

--- a/linux/map.jinja
+++ b/linux/map.jinja
@@ -15,7 +15,7 @@
         'doc_validity_pkgs': ['python-yaml'],
     },
     'Debian': {
-        'pkgs': ['python-apt','vim-nox', 'apt-transport-https'],
+        'pkgs': ['python-apt','vim-nox', 'apt-transport-https', 'libmnl0'],
         'utc': true,
         'user': {},
         'group': {},

--- a/linux/meta/collectd.yml
+++ b/linux/meta/collectd.yml
@@ -1,6 +1,12 @@
 local_plugin:
-  linux_network_interface:
-    plugin: interface
+  linux_network_netlink:
+    plugin: netlink
+    template: linux/files/collectd_netlink.conf
+    ignore_selected: false
+    interfaces:
+    {%- for interface_name in salt['netlink.ls']() %}
+    - {{ interface_name }}
+    {%- endfor %}
   linux_system_cpu:
     plugin: cpu
   linux_system_entropy:


### PR DESCRIPTION
This patch replaces the "interface" collectd plugin by the "netlink" one. The "netlink" plugin provides the same metrics as "interface" but plus other metrics such as the number of dropped packets.