### PR TITLE
Change compute disk warn levels to free MB value

### DIFF
--- a/linux/meta/sensu.yml
+++ b/linux/meta/sensu.yml
@@ -27,7 +27,11 @@ check:
     - {{ system.name|replace('.', '-') }}-{{ system.domain|replace('.', '-') }}
 {%- endif %}
   local_linux_storage_disk_usage:
+    {%- if 'nova.compute' in grains['roles'] %}
+    command: "PATH=$PATH:/usr/lib64/nagios/plugins:/usr/lib/nagios/plugins check_disk -w 20000 -c 10000 -p / -p /var -p /usr -p /tmp -p /var/log"
+    {%- else %}
     command: "PATH=$PATH:/usr/lib64/nagios/plugins:/usr/lib/nagios/plugins check_disk -w 15% -c 5% -p / -p /var -p /usr -p /tmp -p /var/log"
+    {%- endif %}
     interval: 60
     occurrences: 1
     subscribers:


### PR DESCRIPTION
Existing percentages are a poor indication of storage issues on a compute node
as the guest is allowd to consume a majority of the disk. Have computes use a
raw MB value versus a percentage of disk.